### PR TITLE
Fix size for NSOpenGLContext on high DPI displays

### DIFF
--- a/SyphonPayload/SyphonPayload.m
+++ b/SyphonPayload/SyphonPayload.m
@@ -166,8 +166,9 @@ void __SyphonInjectorPublish(CGLContextObj for_ctx, NSSize texture_size)
     {
         my_size = NSMakeSize(forced_width, forced_height);
     } else {
-        
-        my_size = self.view.bounds.size;
+        GLint renderBufDim[4];
+        glGetIntegerv(GL_VIEWPORT, renderBufDim);
+        my_size = NSMakeSize(renderBufDim[2], renderBufDim[3]);
     }
 
     if (capture_buffer == GL_BACK)


### PR DESCRIPTION
On high DPI displays (at least in OSX version 10.10+, possibly even
earlier) view.bounds.size doesn't report the size in pixel values, so a
conversion is needed.

From https://developer.apple.com/library/mac/documentation/Cocoa/Reference/ApplicationKit/Classes/NSView_Class/index.html#//apple_ref/occ/instp/NSView/bounds:
"Developers of OpenGL applications should not rely on the rectangle in
this property to convert coordinates to pixels automatically in future
releases. Instead, you should convert coordinates to device space
explicitly using the convertPointToBase:, convertSizeToBase:, or
convertRectToBase: methods or their earlier counterparts
convertPoint:toView:, convertSize:toView:, or convertRect:toView:."

Since the note doesn't actually specify how the size should be converted
to absolute pixel values without breaking earlier OSX versions and/or
without using deprecated functions, glGetIntegerv(GL_VIEWPORT, …) is
used instead since that seems to reliably report the actual pixel size
of the buffer (at least when used with Dolphin Emulator).
